### PR TITLE
Add option for 4 starting tiles

### DIFF
--- a/src/components/BingoBoard.tsx
+++ b/src/components/BingoBoard.tsx
@@ -78,6 +78,9 @@ class BingoBoard extends React.Component<BoardProps, BoardState> {
     }
 
     getStartTiles() {
+        if (this.props.seed % 10000 === 4444) {
+          return [6, 8, 16, 18]
+        }
         return this.props.seed % 2 === 0 ? [6, 18] : [8, 16]
     }
 


### PR DESCRIPTION
This is a temporary/hacky solution for initial testing for some frequent runners of explo, a long term solution would be to add a mode for four starting tiles.